### PR TITLE
Add SSH key to server

### DIFF
--- a/pkg/hetzner/cloud-config.yaml
+++ b/pkg/hetzner/cloud-config.yaml
@@ -5,8 +5,8 @@ mounts:
     - /home/devpod
     - ext4
     - discard,nofail,defaults
-    - 0
-    - 0
+    - "0"
+    - "0"
 packages:
   - curl
   - ufw
@@ -19,8 +19,6 @@ runcmd:
   - [ service, sshd, restart]
   - [ rm, -f, /root/.ssh/authorized_keys ]
   # Secure UFW
-  # - ufw default deny incoming
-  # - ufw default allow outgoing
   - ufw allow ssh
   - ufw enable
   # Install Docker

--- a/pkg/hetzner/errors.go
+++ b/pkg/hetzner/errors.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	ErrBadSSHKey            = errors.New("bad ssh key")
 	ErrMultipleServersFound = func(name string) error {
 		return fmt.Errorf("multiple server with name %s found", name)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set an SSH key to the server. This avoids an email with the root password being sent.

The `root` user cannot be used to login via SSH, so the `devpod` user **MUST** be used.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #3 

## How to test
<!-- Provide steps to test this PR -->
