### PR TITLE
feat(pkg): handle use of ARM64 images

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -44,16 +44,20 @@ options:
     description: The disk image to use.
     default: docker-ce
   MACHINE_TYPE:
-    description: The machine type to use.
+    description: The machine type to use. ARM64 images (starting "cax") are only available in the Falkenstein (fsn1) region.
     default: cx31
     suggestions:
       - cx11
+      - cax11
       - cpx11
       - cx21
+      - cax21
       - cpx21
       - cx31
+      - cax31
       - cpx31
       - cx41
+      - cax41
       - cpx41
       - cx51
       - cpx51

--- a/pkg/hetzner/hetzner.go
+++ b/pkg/hetzner/hetzner.go
@@ -96,8 +96,12 @@ func (h *Hetzner) BuildServerOptions(ctx context.Context, opts *options.Options)
 		sshKey = uploadedSSHKey
 	}
 
-	// @todo(sje): work out if DevPod handles different architectures
-	image, _, err := h.client.Image.GetByNameAndArchitecture(ctx, opts.DiskImage, hcloud.ArchitectureX86)
+	arch := hcloud.ArchitectureX86
+	if strings.HasPrefix(opts.MachineType, "cax") {
+		// Machines starting "cax" are ARM64
+		arch = hcloud.ArchitectureARM
+	}
+	image, _, err := h.client.Image.GetByNameAndArchitecture(ctx, opts.DiskImage, arch)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In the `v0.1.0` release, there was a `@todo` to handle ARM64 images. Now I've seen how it works in the docs, this enables the ability to use an ARM64 machine.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
