### PR TITLE
fix: arm64 machines no longer falkenstein only

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -44,7 +44,7 @@ options:
     description: The disk image to use.
     default: docker-ce
   MACHINE_TYPE:
-    description: The machine type to use. ARM64 images (starting "cax") are only available in the Falkenstein (fsn1) region.
+    description: The machine type to use.
     default: cx31
     suggestions:
       - cx11


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
ARM64 machines are no longer Falkenstein only, so remove the note

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
