### PR TITLE
fix: switch to static compilation in go for amd64/x86

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -68,7 +68,7 @@ for OS in ${PROVIDER_BUILD_PLATFORMS[@]}; do
     fi
 
     echo "Building for ${OS}/${ARCH}"
-    GOARCH=${ARCH} GOOS=${OS} ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
+    GOARCH=${ARCH} GOOS=${OS} CGO_ENABLED=0 ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
       -o "${PROVIDER_ROOT}/dist/${NAME}" main.go
     shasum -a 256 "${PROVIDER_ROOT}/dist/${NAME}" | cut -d ' ' -f 1 > "${PROVIDER_ROOT}/dist/${NAME}".sha256
   done


### PR DESCRIPTION
## Description
By default, go creates a dynamically linked executable for the platform of the github runner - which is amd64.
The other platforms are statically linked by default during cross-compilation.

see: https://stackoverflow.com/questions/61515186/when-using-cgo-enabled-is-must-and-what-happens

This change defaults the native platform build to a static compilation.
Thus, no loader is required and NixOS works out of the box.

## Related Issue(s)
Fixes #23 

## How to test
Just run `./dist/devpod-provider-hetzner-linux-amd64` after building it using `./hack/build.sh`.
The other binaries should not be affected since they are statically linked by default.

You can check this by running: `readelf -l <binary-path>`
