### PR TITLE
fix: change default machine types

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -46,7 +46,7 @@ options:
     default: docker-ce
   MACHINE_TYPE:
     description: The machine type to use.
-    default: cpx31
+    default: cx32
     suggestions:
       - cx22
       - cx32


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->
CPX31 is 4 vCPUs, 8 GB RAM, 160GB SSD and €15. CX32 is 4 vCPUs, 8 GB Ram, 80GB SSD and €7. As we put all the data into a volume, the disk size is a pointless expense.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
