### PR TITLE
fix: use correct arch for windows amd64 binary in provider.yaml generation

### DIFF
--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -244,7 +244,7 @@ fi`,
 				},
 				{
 					OS:       "windows",
-					Arch:     "arm64",
+					Arch:     "amd64",
 					Path:     fmt.Sprintf("%s/devpod-provider-hetzner-windows-amd64.exe", releaseUrlBase),
 					Checksum: checksum["CHECKSUM_WINDOWS_AMD64"],
 				},


### PR DESCRIPTION
## Description
 fixing the arch for windows amd64 binaries.
Without the fix, the Provider binary for windows amd64 arch wasn't found by devpod installer

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
