### PR TITLE
Remove devpod- prefix and deprecate TOKEN envvar

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,6 @@
     "MACHINE_FOLDER": "/home/vscode/.ssh",
     "MACHINE_TYPE": "cx22",
     "REGION": "nbg1",
-    "TOKEN": "",
     "HCLOUD_TOKEN": ""
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,7 @@ jobs:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
       DISK_IMAGE: docker-ce
       DISK_SIZE: "30"
-      # Use ID only to ensure labels don't overspill
-      MACHINE_ID: ${{ github.run_id }}
+      MACHINE_ID: test-${{ github.run_id }}
       MACHINE_FOLDER: ${{ github.workspace }}./ssh
       MACHINE_TYPE: "cx22"
       REGION: "nbg1"
@@ -93,7 +92,7 @@ jobs:
       - name: Run command
         env:
           COMMAND: hostname
-        run: ./provider command | grep devpod-${MACHINE_ID}
+        run: ./provider command | grep ${MACHINE_ID}
 
       - name: Stop command
         run: ./provider stop
@@ -104,7 +103,7 @@ jobs:
       - name: Run command
         env:
           COMMAND: hostname
-        run: ./provider command | grep devpod-${MACHINE_ID}
+        run: ./provider command | grep ${MACHINE_ID}
 
       - name: Delete command
         run: ./provider delete

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To use this provider in your DevPod setup, you will need to do the following ste
 | `MACHINE_ID` | Unique identifier for the machine | `some-machine-id` |
 | `MACHINE_TYPE` | Hetzner machine size | `cx22` |
 | `REGION` | Hetzner region ID | `nbg1` |
+| `TOKEN` | **Deprecated**. Replaced by `HCLOUD_TOKEN` | - |
 
 ### Testing independently of DevPod
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,10 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		if token := os.Getenv("TOKEN"); token != "" {
+			log.Default.Warn("TOKEN envvar is deprecated in favour of HCLOUD_TOKEN")
+		}
+
 		return nil
 	},
 }

--- a/hack/hcloud_destroy.sh
+++ b/hack/hcloud_destroy.sh
@@ -17,7 +17,7 @@
 set -e
 
 echo "Listing volumes"
-volumes=$(hcloud volume list -l machineId=devpod-${MACHINE_ID} -o noheader -o columns=id)
+volumes=$(hcloud volume list -l machineId=${MACHINE_ID} -o noheader -o columns=id)
 
 for i in ${volumes}; do
   echo "Detaching volume ${i} from server"
@@ -28,7 +28,7 @@ for i in ${volumes}; do
 done
 
 echo "Listing servers"
-servers=$(hcloud server list -l machineId=devpod-${MACHINE_ID} -o noheader -o columns=id)
+servers=$(hcloud server list -l machineId=${MACHINE_ID} -o noheader -o columns=id)
 
 for i in ${servers}; do
   echo "Deleting server ${i}"
@@ -36,7 +36,7 @@ for i in ${servers}; do
 done
 
 echo "Listing SSH keys"
-ssh_keys=$(hcloud ssh-key list -l machineId=devpod-${MACHINE_ID} -o noheader -o columns=id)
+ssh_keys=$(hcloud ssh-key list -l machineId=${MACHINE_ID} -o noheader -o columns=id)
 
 for i in ${ssh_keys}; do
   echo "Deleting SSH key ${i}"

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -49,8 +49,8 @@ func FromEnv(skipMachine bool) (*Options, error) {
 		}
 	}
 
-	// DevPod uses "TOKEN", but Hetzner uses "HCLOUD_TOKEN" - allow HCLOUD_TOKEN for development
-	retOptions.Token, err = fromEnvOrError("TOKEN", "HCLOUD_TOKEN")
+	// TOKEN is deprecated
+	retOptions.Token, err = fromEnvOrError("HCLOUD_TOKEN", "TOKEN")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -42,8 +42,6 @@ func FromEnv(skipMachine bool) (*Options, error) {
 		if err != nil {
 			return nil, err
 		}
-		// prefix with devpod-
-		retOptions.MachineID = "devpod-" + retOptions.MachineID
 
 		retOptions.MachineFolder, err = fromEnvOrError("MACHINE_FOLDER")
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes the `devpod-` prefix from resources - the `type=devpod` now does this job.

Deprecates the use of the `TOKEN` envvar - use `HCLOUD_TOKEN` instead

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
