### PR TITLE
feat: support numeric image IDs for Hetzner snapshots

### DIFF
--- a/pkg/hetzner/hetzner.go
+++ b/pkg/hetzner/hetzner.go
@@ -143,9 +143,19 @@ func (h *Hetzner) BuildServerOptions(
 		// Machines starting "cax" are ARM64
 		arch = hcloud.ArchitectureARM
 	}
-	image, _, err := h.client.Image.GetByNameAndArchitecture(ctx, opts.DiskImage, arch)
-	if err != nil {
-		return nil, nil, nil, err
+
+	var image *hcloud.Image
+	if id, err := strconv.ParseInt(opts.DiskImage, 10, 64); err == nil {
+		// Numeric ID — look up directly (supports snapshots, which have no name)
+		image, _, err = h.client.Image.GetByID(ctx, id)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	} else {
+		image, _, err = h.client.Image.GetByNameAndArchitecture(ctx, opts.DiskImage, arch)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	if image == nil {
 		return nil, nil, nil, ErrUnknownDiskImage


### PR DESCRIPTION
## Problem

`DISK_IMAGE` currently only supports named images via `GetByNameAndArchitecture`. Hetzner **snapshots** have no `name` field — only a numeric ID and a description. This makes it impossible to boot a DevPod workspace from a snapshot, even though snapshots are useful for pre-baking Docker images and other setup to speed up workspace creation.

## Solution

If `DISK_IMAGE` is a numeric string, look up the image by ID using `Image.GetByID`. Otherwise fall back to the existing name+architecture lookup. This is fully backwards-compatible — existing string-based `DISK_IMAGE` values continue to work unchanged.

## Usage

```bash
devpod up github.com/my/workspace \
  --provider hetzner \
  --provider-option DISK_IMAGE=123456789
```

## Changes

- `pkg/hetzner/hetzner.go`: detect numeric `DISK_IMAGE` and use `GetByID` instead of `GetByNameAndArchitecture`

`strconv` was already imported so no new dependencies are needed.